### PR TITLE
Fix multi-line string indentation

### DIFF
--- a/alejandra4/default.nix
+++ b/alejandra4/default.nix
@@ -26,6 +26,8 @@ rustPlatform.buildRustPackage rec {
     postPatch = ''
       substituteInPlace src/alejandra/src/builder.rs \
           --replace "2 * build_ctx.indentation" "4 * build_ctx.indentation"
+      substituteInPlace src/alejandra/src/rules/string.rs \
+          --replace 'format!("  {}", line)' 'format!("    {}", line)'
 
       rm -r src/alejandra/tests
     '';


### PR DESCRIPTION
The indentation for multi-line strings doesn't follow the general rule. Because of that the indentation has to be changed at an additional place.